### PR TITLE
acl: fix failure to automatically update

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,5 +1,5 @@
 # Access Control List for JupyterHub, will be written to a file mounted in
-# /etc/jupyterhub/acl.yaml and parsed by custom authenticator logic.
+# /etc/jupyterhub/acl/acl.yaml and parsed by custom authenticator logic.
 acl.yaml: {}
 
 jupyterhub:
@@ -28,7 +28,7 @@ jupyterhub:
             Note that @lru_cache memoizes this function so it only runs once.
             """
             acl = {}
-            path = "/etc/jupyterhub/acl.yaml"
+            path = "/etc/jupyterhub/acl/acl.yaml"
             if os.path.exists(path):
                 print(f"Loading Access Control List (ACL) from {path}")
                 with open(path) as f:

--- a/deployments/hub-neurohackademy-org/config/prod.yaml
+++ b/deployments/hub-neurohackademy-org/config/prod.yaml
@@ -97,9 +97,8 @@ jupyterhub:
         configMap:
           name: hub-usr-local-share-jupyterhub-static-external
     extraVolumeMounts:
-      - mountPath: /etc/jupyterhub/acl.yaml
+      - mountPath: /etc/jupyterhub/acl
         name: hub-etc-jupyterhub-acl
-        subPath: acl.yaml
       - mountPath: /etc/jupyterhub/templates
         name: hub-etc-jupyterhub-templates
       - mountPath: /usr/local/share/jupyterhub/static/external


### PR DESCRIPTION
Closes #22 by not using subPath while mounting the acl.yaml file to avoid a known limitation about configmap/secrets not being updated automatically when the configmap/secret changes.