### PR TITLE
added "neuropythy" to the hub env

### DIFF
--- a/deployments/hub-neurohackademy-org/image/environment.yml
+++ b/deployments/hub-neurohackademy-org/image/environment.yml
@@ -38,7 +38,7 @@ dependencies:
     - mne
     - numpy
     - scipy
-    - git+https://github.com/noahbenson/neuropythy.git@e9c284d51dc5504e0e938d562a2fae668e953053
+    - neuropythy
     # -----------------------------------------------------------------------
 
     # Needed by the neurohackademy Helm chart


### PR DESCRIPTION
Fixed the setup issue--should now work fine just as a "neuropythy" pip install.
(Just tested on the hub environment and it installed fine.)