### PR TITLE
storage: small followup fix of rsync

### DIFF
--- a/chart/templates/nfs-node-cacher-daemonset.yaml
+++ b/chart/templates/nfs-node-cacher-daemonset.yaml
@@ -54,7 +54,7 @@ spec:
             - "-c"
             - |
                 while true; do
-                  rsync -avP /nh/data /nh/data-cache;
+                  rsync -avP /nh/data/ /nh/data-cache;
                   sleep 60;
                 done
           volumeMounts:


### PR DESCRIPTION
Complements #62 to close #60. I ended up creating a folder within /nh/data-cache named data without this small detail fix.