### PR TITLE
[enh] Add myst-nb to image

### DIFF
--- a/deployments/hub-neurohackademy-org/image/environment.yml
+++ b/deployments/hub-neurohackademy-org/image/environment.yml
@@ -32,6 +32,7 @@ dependencies:
     - transforms3d
     - rise
     - jupytext
+    - myst-nb
     - numba
     - pandas
     - awscli


### PR DESCRIPTION
This isn't strictly necessary, but for the Nilearn tutorial on Wed I've created a Jupyter-Book ([viewable here](https://emdupre.github.io/nha2020-nilearn/)).
I've set it to point to this JupyterHub, but when it launches (successfully) the cells aren't correctly identified. I think this is because I created the book in MyST.

It'd be great to add MyST-NB, and hopefully have the notebooks open correctly in JupyterLab. I'm also uploading the built notebooks to the [course materials](https://github.com/neurohackademy/nh2020-curriculum), though, so it's not a big deal either way.

Thanks !