### PR TITLE
[fix] Update jupytext dependency

### DIFF
--- a/deployments/hub-neurohackademy-org/image/environment.yml
+++ b/deployments/hub-neurohackademy-org/image/environment.yml
@@ -31,7 +31,7 @@ dependencies:
     - nilearn
     - transforms3d
     - rise
-    - jupytext
+    - jupytext[myst]
     - myst-nb
     - numba
     - pandas


### PR DESCRIPTION
Following discussion in https://github.com/executablebooks/MyST-NB/issues/216, updates the Jupytext dependency to specifically install `jupytext[myst]` in the hopes that this will correctly render MyST markdown documents !