### PR TITLE
storage: rsync ran out of memory

### DIFF
--- a/chart/templates/nfs-node-cacher-daemonset.yaml
+++ b/chart/templates/nfs-node-cacher-daemonset.yaml
@@ -68,10 +68,10 @@ spec:
           resources:
             requests:
               cpu: "0.5"
-              memory: 4Gi
+              memory: 16Gi
             limits:
-              cpu: "1"
-              memory: 4Gi
+              cpu: "16"
+              memory: 16Gi
 
       terminationGracePeriodSeconds: 0
       nodeSelector:


### PR DESCRIPTION
Closes #99 preliminary. I need to monitor this going onwards as well. How much memory will rsync need as the NFS drive grow? Can this be capped or limited somehow?

